### PR TITLE
Update Emitter to use SimulariumIO AgentData from lists

### DIFF
--- a/vivarium_models/processes/simularium_emitter.py
+++ b/vivarium_models/processes/simularium_emitter.py
@@ -3,7 +3,6 @@ from typing import Any, Dict
 from vivarium.core.emitter import Emitter
 
 import numpy as np
-import pandas as pd
 from simulariumio import (
     TrajectoryConverter,
     TrajectoryData,


### PR DESCRIPTION
Problem
=======
We added support to handling jagged lists in AgentData (in [this ticket](https://github.com/simularium/simulariumio/issues/63)), so we should use this in SimulariumEmitter

[Link to ticket](https://github.com/simularium/vivarium-models/issues/21)
